### PR TITLE
Add automated sample generation and data refresh tooling

### DIFF
--- a/openfpl/__init__.py
+++ b/openfpl/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for working with OpenFPL datasets and models."""

--- a/openfpl/data_store.py
+++ b/openfpl/data_store.py
@@ -1,0 +1,24 @@
+"""Utilities for persisting raw data fetched from the FPL API."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def save_json(payload: Dict[str, Any], path: Path) -> None:
+    """Serialize *payload* as JSON to *path*."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    """Load JSON data from *path*."""
+
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+__all__ = ["save_json", "load_json"]

--- a/openfpl/fpl_client.py
+++ b/openfpl/fpl_client.py
@@ -1,0 +1,72 @@
+"""Client for interacting with the public Fantasy Premier League API."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+
+
+DEFAULT_BASE_URL = "https://fantasy.premierleague.com/api"
+DEFAULT_USER_AGENT = "OpenFPL/0.1 (+https://github.com/)"
+
+
+@dataclass
+class FPLClient:
+    """Simple wrapper around the Fantasy Premier League HTTP API.
+
+    Parameters
+    ----------
+    base_url:
+        Base URL for the API. This is exposed for testability.
+    user_agent:
+        User agent header sent with every request.
+    proxy_url:
+        Optional explicit proxy URL. When omitted the values from the
+        ``HTTP_PROXY``/``HTTPS_PROXY`` environment variables (if any) are used.
+    timeout:
+        Request timeout in seconds.
+    """
+
+    base_url: str = DEFAULT_BASE_URL
+    user_agent: str = DEFAULT_USER_AGENT
+    proxy_url: Optional[str] = None
+    timeout: int = 30
+    trust_env: bool = True
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
+        self._session = requests.Session()
+        self._session.trust_env = self.trust_env
+        self._session.headers.update({"User-Agent": self.user_agent})
+        self._proxies: Optional[Dict[str, str]]
+        if self.proxy_url:
+            self._proxies = {"http": self.proxy_url, "https": self.proxy_url}
+        else:
+            self._proxies = None
+
+    def _get(self, path: str) -> Dict[str, Any]:
+        response = self._session.get(
+            f"{self.base_url.rstrip('/')}/{path.lstrip('/')}",
+            timeout=self.timeout,
+            proxies=self._proxies,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def get_bootstrap_static(self) -> Dict[str, Any]:
+        """Return the payload from ``/bootstrap-static/``."""
+
+        return self._get("bootstrap-static/")
+
+    def get_fixtures(self) -> Dict[str, Any]:
+        """Return the payload from ``/fixtures/``."""
+
+        return self._get("fixtures/")
+
+    def get_event_live(self, event_id: int) -> Dict[str, Any]:
+        """Return the live data for a given gameweek."""
+
+        return self._get(f"event/{event_id}/live/")
+
+
+__all__ = ["FPLClient"]

--- a/openfpl/refresh.py
+++ b/openfpl/refresh.py
@@ -1,0 +1,53 @@
+"""Refresh helpers for downloading Fantasy Premier League data."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Optional
+
+from .data_store import save_json
+from .fpl_client import FPLClient
+
+
+def _determine_event_ids_to_download(bootstrap: dict, next_event_id: Optional[int]) -> Iterable[int]:
+    for event in bootstrap.get("events", []):
+        event_id = event["id"]
+        if event.get("finished") or event.get("data_checked"):
+            if next_event_id is None or event_id < next_event_id:
+                yield event_id
+
+
+def refresh_fpl_data(output_dir: Path, *, client: Optional[FPLClient] = None) -> None:
+    """Download the latest public data from the Fantasy Premier League API.
+
+    The files are stored under *output_dir* using the following structure::
+
+        bootstrap-static.json
+        fixtures.json
+        events/<event_id>.json
+
+    Parameters
+    ----------
+    output_dir:
+        Directory in which the files should be stored.
+    client:
+        Optional :class:`~openfpl.fpl_client.FPLClient` instance. When omitted a
+        default client is created.
+    """
+
+    output_dir = Path(output_dir)
+    client = client or FPLClient()
+
+    bootstrap = client.get_bootstrap_static()
+    save_json(bootstrap, output_dir / "bootstrap-static.json")
+
+    fixtures = client.get_fixtures()
+    save_json(fixtures, output_dir / "fixtures.json")
+
+    next_event_id = next((event["id"] for event in bootstrap.get("events", []) if event.get("is_next")), None)
+
+    for event_id in _determine_event_ids_to_download(bootstrap, next_event_id):
+        event_payload = client.get_event_live(event_id)
+        save_json(event_payload, output_dir / "events" / f"{event_id}.json")
+
+
+__all__ = ["refresh_fpl_data"]

--- a/openfpl/samples.py
+++ b/openfpl/samples.py
@@ -1,0 +1,537 @@
+"""Generation of OpenFPL input samples from raw Fantasy Premier League data."""
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .data_store import load_json
+
+ROLLING_WINDOWS: Sequence[int] = (1, 3, 5, 10, 38)
+RELEVANT_MINUTES_THRESHOLD = 45
+POSITION_MAP = {1: "GK", 2: "DEF", 3: "MID", 4: "FWD"}
+
+PLAYER_STAT_MAP: Mapping[str, str] = {
+    "player fpl points": "total_points",
+    "player minutes played": "minutes",
+    "player influence": "influence",
+    "player creativity": "creativity",
+    "player threat": "threat",
+    "player goals scored": "goals_scored",
+    "player penalties missed": "penalties_missed",
+    "player assists": "assists",
+    "player goals conceded": "goals_conceded",
+    "player own goals": "own_goals",
+    "player saves": "saves",
+    "player penalties saved": "penalties_saved",
+    "player yellow cards": "yellow_cards",
+    "player red cards": "red_cards",
+    "player bps": "bps",
+    "player fpl bonus points": "bonus",
+    "player shots": "total_shots",
+    "player key passes": "key_passes",
+    "player xa": "expected_assists",
+    "player xg": "expected_goals",
+    "player xgchain": "xg_chain",
+    "player xgbuildup": "xg_buildup",
+}
+
+TEAM_STAT_MAP: Mapping[str, str] = {
+    "team goals scored": "goals_for",
+    "team goals conceded": "goals_against",
+    "team league rank": "league_rank_post",
+    "team opponent league rank": "opponent_rank_pre",
+    "team xg": "xg",
+    "team xga": "xga",
+    "team deep allowed": "deep_allowed",
+    "team ppda allowed att": "ppda_allowed_att",
+    "team ppda allowed def": "ppda_allowed_def",
+    "team deep": "deep",
+    "team ppda att": "ppda_att",
+    "team ppda def": "ppda_def",
+}
+
+OPPONENT_PREFIX = "opponent "
+# Only a subset of team metrics are mirrored for opponents in the input file.
+OPPONENT_FEATURE_BASES = (
+    "team goals scored",
+    "team goals conceded",
+    "team xg",
+    "team deep allowed",
+    "team ppda allowed att",
+    "team ppda allowed def",
+    "team xga",
+    "team deep",
+    "team ppda att",
+    "team ppda def",
+)
+STATUS_COLUMNS = ["status player availability", "status team league rank", "status opponent league rank"]
+METADATA_COLUMNS = ["season", "gw", "position", "player", "team", "opponent", "home"]
+
+
+@dataclass
+class PlayerInfo:
+    id: int
+    first_name: str
+    second_name: str
+    team_id: int
+    element_type: int
+    status: str
+
+    @property
+    def full_name(self) -> str:
+        if self.first_name and self.second_name:
+            return f"{self.first_name} {self.second_name}".strip()
+        return self.first_name or self.second_name
+
+
+@dataclass
+class FixtureInfo:
+    event: int
+    team_h: int
+    team_a: int
+    team_h_score: Optional[int]
+    team_a_score: Optional[int]
+    finished: bool
+
+
+@dataclass
+class TeamEventRecord:
+    event: int
+    team_id: int
+    opponent_id: int
+    was_home: bool
+    goals_for: float
+    goals_against: float
+    league_rank_pre: Optional[float]
+    league_rank_post: Optional[float]
+    opponent_rank_pre: Optional[float]
+    xg: float
+    xga: float
+
+
+STATUS_MAP = {
+    "a": 1.0,
+    "d": 0.5,
+    "i": 0.0,
+    "s": 0.0,
+    "u": 0.0,
+    "n": 0.0,
+}
+
+
+def _infer_season(events: Iterable[dict]) -> str:
+    deadlines = [event.get("deadline_time") for event in events if event.get("deadline_time")]
+    if not deadlines:
+        current_year = datetime.utcnow().year
+    else:
+        first_deadline = min(deadlines)
+        current_year = datetime.fromisoformat(first_deadline.replace("Z", "+00:00")).year
+    return f"{current_year}-{(current_year + 1) % 100:02d}"
+
+
+def _build_player_lookup(bootstrap: dict) -> Dict[int, PlayerInfo]:
+    players = {}
+    for element in bootstrap.get("elements", []):
+        players[element["id"]] = PlayerInfo(
+            id=element["id"],
+            first_name=element.get("first_name", ""),
+            second_name=element.get("second_name", ""),
+            team_id=element.get("team"),
+            element_type=element.get("element_type"),
+            status=element.get("status", ""),
+        )
+    return players
+
+
+def _build_team_lookup(bootstrap: dict) -> Dict[int, str]:
+    return {team["id"]: team.get("name", str(team["id"])) for team in bootstrap.get("teams", [])}
+
+
+def _build_fixtures(fixtures_payload: Iterable[dict]) -> Dict[int, List[FixtureInfo]]:
+    fixtures_by_event: Dict[int, List[FixtureInfo]] = defaultdict(list)
+    for fixture in fixtures_payload:
+        event = fixture.get("event")
+        if event is None:
+            continue
+        fixtures_by_event[event].append(
+            FixtureInfo(
+                event=event,
+                team_h=fixture["team_h"],
+                team_a=fixture["team_a"],
+                team_h_score=fixture.get("team_h_score"),
+                team_a_score=fixture.get("team_a_score"),
+                finished=fixture.get("finished", False),
+            )
+        )
+    return fixtures_by_event
+
+
+def _build_fixture_lookup(fixtures_by_event: Mapping[int, Sequence[FixtureInfo]]) -> Dict[int, Dict[int, Dict[str, object]]]:
+    lookup: Dict[int, Dict[int, Dict[str, object]]] = defaultdict(dict)
+    for event, fixtures in fixtures_by_event.items():
+        for fixture in fixtures:
+            lookup[event][fixture.team_h] = {"opponent": fixture.team_a, "was_home": True}
+            lookup[event][fixture.team_a] = {"opponent": fixture.team_h, "was_home": False}
+    return lookup
+
+
+def _collect_player_event_stats(
+    event_payloads: Mapping[int, dict],
+    player_lookup: Mapping[int, PlayerInfo],
+    fixture_lookup: Mapping[int, Mapping[int, Mapping[str, object]]],
+) -> pd.DataFrame:
+    rows: List[dict] = []
+    for event_id, payload in event_payloads.items():
+        team_mapping = fixture_lookup.get(event_id, {})
+        for element in payload.get("elements", []):
+            player_id = element["id"]
+            player = player_lookup.get(player_id)
+            if not player:
+                continue
+            team_info = team_mapping.get(player.team_id)
+            if not team_info:
+                continue
+            stats = element.get("stats", {})
+            record = {
+                "event": event_id,
+                "player_id": player_id,
+                "team_id": player.team_id,
+                "opponent_team_id": team_info["opponent"],
+                "was_home": bool(team_info["was_home"]),
+            }
+            for alias, key in PLAYER_STAT_MAP.items():
+                value = stats.get(key)
+                if value in ("", None):
+                    record[key] = np.nan
+                else:
+                    try:
+                        record[key] = float(value)
+                    except (TypeError, ValueError):
+                        record[key] = np.nan
+            record["minutes"] = float(stats.get("minutes", 0))
+            record["total_points"] = float(stats.get("total_points", 0))
+            for key in (
+                "goals_scored",
+                "assists",
+                "goals_conceded",
+                "own_goals",
+                "penalties_saved",
+                "penalties_missed",
+                "yellow_cards",
+                "red_cards",
+                "saves",
+                "bps",
+                "bonus",
+                "total_shots",
+                "key_passes",
+            ):
+                record[key] = float(stats.get(key, 0))
+            rows.append(record)
+    if not rows:
+        return pd.DataFrame(columns=["event", "player_id", "team_id"])
+    df = pd.DataFrame(rows)
+    df.sort_values(["player_id", "event"], inplace=True)
+    return df
+
+
+def _calculate_table_ranks(table: Mapping[int, MutableMapping[str, float]]) -> Dict[int, float]:
+    sorted_teams = sorted(
+        table.items(),
+        key=lambda item: (
+            -item[1]["points"],
+            -item[1]["goal_difference"],
+            -item[1]["goals_for"],
+        ),
+    )
+    return {team_id: float(index + 1) for index, (team_id, _) in enumerate(sorted_teams)}
+
+
+def _update_table(table: Dict[int, Dict[str, float]], fixture: FixtureInfo) -> None:
+    if fixture.team_h_score is None or fixture.team_a_score is None:
+        return
+    home, away = fixture.team_h, fixture.team_a
+    home_goals = float(fixture.team_h_score)
+    away_goals = float(fixture.team_a_score)
+    table.setdefault(home, {"points": 0.0, "goal_difference": 0.0, "goals_for": 0.0, "goals_against": 0.0})
+    table.setdefault(away, {"points": 0.0, "goal_difference": 0.0, "goals_for": 0.0, "goals_against": 0.0})
+
+    if home_goals > away_goals:
+        table[home]["points"] += 3
+    elif home_goals < away_goals:
+        table[away]["points"] += 3
+    else:
+        table[home]["points"] += 1
+        table[away]["points"] += 1
+
+    table[home]["goals_for"] += home_goals
+    table[home]["goals_against"] += away_goals
+    table[home]["goal_difference"] = table[home]["goals_for"] - table[home]["goals_against"]
+
+    table[away]["goals_for"] += away_goals
+    table[away]["goals_against"] += home_goals
+    table[away]["goal_difference"] = table[away]["goals_for"] - table[away]["goals_against"]
+
+
+def _build_team_event_records(
+    fixtures_by_event: Mapping[int, Sequence[FixtureInfo]],
+    player_event_df: pd.DataFrame,
+    next_event_id: int,
+) -> tuple[Dict[int, List[TeamEventRecord]], Dict[int, float]]:
+    table: Dict[int, Dict[str, float]] = {}
+    pre_ranks: Dict[int, Dict[int, float]] = {}
+    post_ranks: Dict[int, Dict[int, float]] = {}
+
+    events = [event for event in sorted(fixtures_by_event) if event < next_event_id]
+
+    for event in events:
+        pre_ranks[event] = _calculate_table_ranks(table)
+        for fixture in fixtures_by_event[event]:
+            _update_table(table, fixture)
+        post_ranks[event] = _calculate_table_ranks(table)
+
+    team_records: Dict[int, List[TeamEventRecord]] = defaultdict(list)
+
+    if player_event_df.empty:
+        grouped_xg = pd.DataFrame()
+    else:
+        grouped_xg = (
+            player_event_df[player_event_df["event"] < next_event_id]
+            .groupby(["event", "team_id"])
+            .agg({"expected_goals": "sum"})
+            .rename(columns={"expected_goals": "xg"})
+        )
+
+    for event in events:
+        for fixture in fixtures_by_event[event]:
+            if fixture.team_h_score is None or fixture.team_a_score is None:
+                continue
+            def _xg(event_id: int, team_id: int) -> float:
+                if grouped_xg.empty:
+                    return float("nan")
+                try:
+                    return float(grouped_xg.loc[(event_id, team_id), "xg"])
+                except KeyError:
+                    return float("nan")
+
+            home_xg = _xg(event, fixture.team_h)
+            away_xg = _xg(event, fixture.team_a)
+
+            pre_rank = pre_ranks.get(event, {})
+            post_rank = post_ranks.get(event, {})
+
+            team_records[fixture.team_h].append(
+                TeamEventRecord(
+                    event=event,
+                    team_id=fixture.team_h,
+                    opponent_id=fixture.team_a,
+                    was_home=True,
+                    goals_for=float(fixture.team_h_score),
+                    goals_against=float(fixture.team_a_score),
+                    league_rank_pre=pre_rank.get(fixture.team_h),
+                    league_rank_post=post_rank.get(fixture.team_h),
+                    opponent_rank_pre=pre_rank.get(fixture.team_a),
+                    xg=home_xg,
+                    xga=away_xg,
+                )
+            )
+            team_records[fixture.team_a].append(
+                TeamEventRecord(
+                    event=event,
+                    team_id=fixture.team_a,
+                    opponent_id=fixture.team_h,
+                    was_home=False,
+                    goals_for=float(fixture.team_a_score),
+                    goals_against=float(fixture.team_h_score),
+                    league_rank_pre=pre_rank.get(fixture.team_a),
+                    league_rank_post=post_rank.get(fixture.team_a),
+                    opponent_rank_pre=pre_rank.get(fixture.team_h),
+                    xg=away_xg,
+                    xga=home_xg,
+                )
+            )
+    final_ranks = _calculate_table_ranks(table)
+    return team_records, final_ranks
+
+
+def _compute_player_features(history: pd.DataFrame) -> Dict[str, float]:
+    features: Dict[str, float] = {}
+    if history.empty:
+        for stat in PLAYER_STAT_MAP:
+            for window in ROLLING_WINDOWS:
+                features[f"{stat} {window}"] = np.nan
+        return features
+    for window in ROLLING_WINDOWS:
+        window_df = history.tail(window)
+        features[f"player fpl points {window}"] = window_df["total_points"].mean()
+        relevant = window_df[window_df["minutes"] >= RELEVANT_MINUTES_THRESHOLD]
+        features[f"player relevant fpl points {window}"] = relevant["total_points"].mean() if not relevant.empty else np.nan
+        for alias, column in PLAYER_STAT_MAP.items():
+            if alias in {"player fpl points", "player relevant fpl points"}:
+                continue
+            col_values = window_df[column] if column in window_df else pd.Series(dtype=float)
+            features[f"{alias} {window}"] = col_values.mean() if not col_values.empty else np.nan
+    return features
+
+
+def _compute_team_features(records: Sequence[TeamEventRecord]) -> Dict[str, float]:
+    features: Dict[str, float] = {}
+    if not records:
+        for alias in TEAM_STAT_MAP:
+            for window in ROLLING_WINDOWS:
+                features[f"{alias} {window}"] = np.nan
+        return features
+
+    df = pd.DataFrame([r.__dict__ for r in records])
+    for window in ROLLING_WINDOWS:
+        window_df = df.tail(window)
+        for alias, column in TEAM_STAT_MAP.items():
+            if column not in window_df:
+                features[f"{alias} {window}"] = np.nan
+            else:
+                features[f"{alias} {window}"] = window_df[column].mean()
+    return features
+
+
+def _build_expected_columns(sample_template_path: Optional[Path]) -> List[str]:
+    if sample_template_path and sample_template_path.exists():
+        with sample_template_path.open("r", encoding="utf-8") as fh:
+            header_line = fh.readline().strip()
+        if header_line:
+            return header_line.split(",")
+    columns: List[str] = list(METADATA_COLUMNS)
+    for window in ROLLING_WINDOWS:
+        columns.append(f"player fpl points {window}")
+        columns.append(f"player relevant fpl points {window}")
+    for alias in PLAYER_STAT_MAP:
+        if alias == "player fpl points":
+            continue
+        for window in ROLLING_WINDOWS:
+            columns.append(f"{alias} {window}")
+    for alias in TEAM_STAT_MAP:
+        for window in ROLLING_WINDOWS:
+            columns.append(f"{alias} {window}")
+    for alias in OPPONENT_FEATURE_BASES:
+        suffix = alias[len("team ") :]
+        for window in ROLLING_WINDOWS:
+            columns.append(f"{OPPONENT_PREFIX}{suffix} {window}")
+    columns.extend(STATUS_COLUMNS)
+    return columns
+
+
+def _build_upcoming_fixtures(fixtures_by_event: Mapping[int, Sequence[FixtureInfo]], event_id: int) -> Dict[int, List[Dict[str, object]]]:
+    upcoming: Dict[int, List[Dict[str, object]]] = defaultdict(list)
+    for fixture in fixtures_by_event.get(event_id, []):
+        upcoming[fixture.team_h].append({"opponent": fixture.team_a, "home": True})
+        upcoming[fixture.team_a].append({"opponent": fixture.team_h, "home": False})
+    return upcoming
+
+
+def generate_samples(
+    raw_data_dir: Path,
+    output_path: Path,
+    *,
+    sample_template: Optional[Path] = None,
+) -> pd.DataFrame:
+    """Generate the OpenFPL input samples for the upcoming gameweek."""
+
+    raw_data_dir = Path(raw_data_dir)
+    output_path = Path(output_path)
+
+    bootstrap = load_json(raw_data_dir / "bootstrap-static.json")
+    fixtures_payload = load_json(raw_data_dir / "fixtures.json")
+
+    event_payloads: Dict[int, dict] = {}
+    events_dir = raw_data_dir / "events"
+    if events_dir.exists():
+        for path in events_dir.glob("*.json"):
+            event_payloads[int(path.stem)] = load_json(path)
+
+    events = bootstrap.get("events", [])
+    next_event = next((event for event in events if event.get("is_next")), None)
+    if not next_event:
+        raise ValueError("Unable to determine upcoming gameweek from bootstrap data")
+    next_event_id = next_event["id"]
+
+    season = _infer_season(events)
+
+    fixtures_by_event = _build_fixtures(fixtures_payload)
+    fixture_lookup = _build_fixture_lookup(fixtures_by_event)
+
+    player_lookup = _build_player_lookup(bootstrap)
+    team_lookup = _build_team_lookup(bootstrap)
+
+    player_event_df = _collect_player_event_stats(event_payloads, player_lookup, fixture_lookup)
+
+    team_records, final_ranks = _build_team_event_records(fixtures_by_event, player_event_df, next_event_id)
+    team_features: Dict[int, Dict[str, float]] = {}
+    for team_id, records in team_records.items():
+        team_features[team_id] = _compute_team_features(records)
+
+    upcoming_fixtures = _build_upcoming_fixtures(fixtures_by_event, next_event_id)
+
+    columns = _build_expected_columns(sample_template)
+
+    rows: List[Dict[str, object]] = []
+    current_team_ranks: Dict[int, Optional[float]] = {}
+    if final_ranks:
+        current_team_ranks.update(final_ranks)
+    if team_records:
+        for team_id, records in team_records.items():
+            if records and records[-1].league_rank_post is not None:
+                current_team_ranks.setdefault(team_id, records[-1].league_rank_post)
+
+    for player_id, info in player_lookup.items():
+        team_id = info.team_id
+        upcoming = upcoming_fixtures.get(team_id)
+        if not upcoming:
+            continue
+        history = player_event_df[
+            (player_event_df["player_id"] == player_id)
+            & (player_event_df["event"] < next_event_id)
+        ]
+        player_features = _compute_player_features(history)
+        team_feature_values = team_features.get(team_id, {})
+        for fixture in upcoming:
+            opponent_id = fixture["opponent"]
+            opponent_features = team_features.get(opponent_id, {})
+            row: Dict[str, object] = {
+                "season": season,
+                "gw": next_event_id,
+                "position": POSITION_MAP.get(info.element_type, ""),
+                "player": info.full_name,
+                "team": team_lookup.get(team_id, str(team_id)),
+                "opponent": team_lookup.get(opponent_id, str(opponent_id)),
+                "home": bool(fixture["home"]),
+            }
+            row.update(player_features)
+            row.update(team_feature_values)
+            for alias, value in opponent_features.items():
+                if alias.startswith("team league rank") or alias.startswith("team opponent league rank"):
+                    continue
+                if not any(alias.startswith(base) for base in OPPONENT_FEATURE_BASES):
+                    continue
+                suffix = alias[len("team ") :]
+                row[f"{OPPONENT_PREFIX}{suffix}"] = value
+            row["status player availability"] = STATUS_MAP.get(info.status, np.nan)
+            row["status team league rank"] = current_team_ranks.get(team_id)
+            row["status opponent league rank"] = current_team_ranks.get(opponent_id)
+            rows.append(row)
+
+    samples_df = pd.DataFrame(rows)
+
+    for column in columns:
+        if column not in samples_df:
+            samples_df[column] = np.nan
+    samples_df = samples_df[columns]
+    samples_df.sort_values(["team", "player"], inplace=True)
+    samples_df.to_csv(output_path, index=False)
+    return samples_df
+
+
+__all__ = ["generate_samples"]

--- a/plug.txt
+++ b/plug.txt
@@ -2,3 +2,4 @@ pandas==2.3.1
 joblib==1.5.1
 xgboost==3.0.2
 scikit-learn==1.7.0
+requests==2.32.5

--- a/scripts/generate_samples.py
+++ b/scripts/generate_samples.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Generate ``data/samples.csv`` for the upcoming Fantasy Premier League gameweek."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Optional
+
+from openfpl.fpl_client import FPLClient
+from openfpl.refresh import refresh_fpl_data
+from openfpl.samples import generate_samples
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--raw-dir",
+        type=Path,
+        default=Path("data/raw/fpl"),
+        help="Directory containing raw FPL API responses (defaults to data/raw/fpl).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data/samples.csv"),
+        help="Location where the generated samples should be written.",
+    )
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=None,
+        help="Optional CSV file whose header defines the expected column order (defaults to the current output file if it exists).",
+    )
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Refresh the raw API data before generating samples.",
+    )
+    parser.add_argument(
+        "--proxy",
+        type=str,
+        default=None,
+        help="Optional proxy URL to use when refreshing data.",
+    )
+    parser.add_argument(
+        "--no-proxy",
+        action="store_true",
+        help="Disable environment proxy settings for HTTP requests.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=30,
+        help="Request timeout in seconds when refreshing (default: 30).",
+    )
+    return parser.parse_args()
+
+
+def resolve_template_path(output: Path, explicit_template: Optional[Path]) -> Optional[Path]:
+    if explicit_template is not None:
+        return explicit_template
+    if output.exists():
+        return output
+    return None
+
+
+def main() -> None:
+    args = parse_args()
+    raw_dir = args.raw_dir
+    if args.refresh:
+        client = FPLClient(proxy_url=args.proxy, timeout=args.timeout, trust_env=not args.no_proxy)
+        refresh_fpl_data(raw_dir, client=client)
+    template = resolve_template_path(args.output, args.template)
+    generate_samples(raw_dir, args.output, sample_template=template)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/refresh_fpl_data.py
+++ b/scripts/refresh_fpl_data.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Download the latest Fantasy Premier League data into ``data/raw/fpl``."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from openfpl.fpl_client import FPLClient
+from openfpl.refresh import refresh_fpl_data
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data/raw/fpl"),
+        help="Directory where the raw JSON responses should be stored.",
+    )
+    parser.add_argument(
+        "--proxy",
+        type=str,
+        default=None,
+        help="Optional proxy URL (e.g. http://proxy:8080). If omitted the environment configuration is used.",
+    )
+    parser.add_argument(
+        "--no-proxy",
+        action="store_true",
+        help="Disable environment proxy settings when making HTTP requests.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=30,
+        help="Request timeout in seconds (default: 30).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    client = FPLClient(proxy_url=args.proxy, timeout=args.timeout, trust_env=not args.no_proxy)
+    refresh_fpl_data(args.output_dir, client=client)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from openfpl.samples import generate_samples
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+
+
+def _build_bootstrap() -> dict:
+    return {
+        "events": [
+            {"id": 1, "finished": True, "deadline_time": "2024-08-10T18:00:00Z", "data_checked": True},
+            {"id": 2, "finished": True, "deadline_time": "2024-08-17T18:00:00Z", "data_checked": True},
+            {"id": 3, "is_next": True, "deadline_time": "2024-08-24T18:00:00Z"},
+        ],
+        "teams": [
+            {"id": 1, "name": "Alpha FC"},
+            {"id": 2, "name": "Beta FC"},
+        ],
+        "elements": [
+            {"id": 101, "first_name": "John", "second_name": "Doe", "team": 1, "element_type": 4, "status": "a"},
+            {"id": 102, "first_name": "Jane", "second_name": "Smith", "team": 2, "element_type": 1, "status": "d"},
+        ],
+    }
+
+
+def _build_fixtures() -> list[dict]:
+    return [
+        {"event": 1, "team_h": 1, "team_a": 2, "team_h_score": 2, "team_a_score": 1, "finished": True},
+        {"event": 2, "team_h": 2, "team_a": 1, "team_h_score": 1, "team_a_score": 0, "finished": True},
+        {"event": 3, "team_h": 1, "team_a": 2, "team_h_score": None, "team_a_score": None, "finished": False},
+    ]
+
+
+def _event_payload(event_id: int) -> dict:
+    if event_id == 1:
+        return {
+            "elements": [
+                {
+                    "id": 101,
+                    "stats": {
+                        "minutes": 90,
+                        "total_points": 8,
+                        "goals_scored": 1,
+                        "assists": 1,
+                        "goals_conceded": 1,
+                        "own_goals": 0,
+                        "penalties_saved": 0,
+                        "penalties_missed": 0,
+                        "yellow_cards": 0,
+                        "red_cards": 0,
+                        "saves": 0,
+                        "bps": 32,
+                        "bonus": 3,
+                        "total_shots": 3,
+                        "key_passes": 2,
+                        "influence": "45.0",
+                        "creativity": "20.0",
+                        "threat": "50.0",
+                        "expected_goals": "0.6",
+                        "expected_assists": "0.4",
+                        "xg_chain": "0.9",
+                        "xg_buildup": "0.3",
+                    },
+                },
+                {
+                    "id": 102,
+                    "stats": {
+                        "minutes": 90,
+                        "total_points": 2,
+                        "goals_scored": 0,
+                        "assists": 0,
+                        "goals_conceded": 2,
+                        "own_goals": 0,
+                        "penalties_saved": 0,
+                        "penalties_missed": 0,
+                        "yellow_cards": 0,
+                        "red_cards": 0,
+                        "saves": 3,
+                        "bps": 20,
+                        "bonus": 0,
+                        "total_shots": 0,
+                        "key_passes": 0,
+                        "influence": "10.0",
+                        "creativity": "1.0",
+                        "threat": "0.5",
+                        "expected_goals": "0.0",
+                        "expected_assists": "0.0",
+                        "xg_chain": "0.0",
+                        "xg_buildup": "0.0",
+                    },
+                },
+            ]
+        }
+    return {
+        "elements": [
+            {
+                "id": 101,
+                "stats": {
+                    "minutes": 85,
+                    "total_points": 2,
+                    "goals_scored": 0,
+                    "assists": 0,
+                    "goals_conceded": 1,
+                    "own_goals": 0,
+                    "penalties_saved": 0,
+                    "penalties_missed": 0,
+                    "yellow_cards": 1,
+                    "red_cards": 0,
+                    "saves": 0,
+                    "bps": 14,
+                    "bonus": 0,
+                    "total_shots": 1,
+                    "key_passes": 1,
+                    "influence": "18.0",
+                    "creativity": "15.0",
+                    "threat": "22.0",
+                    "expected_goals": "0.1",
+                    "expected_assists": "0.05",
+                    "xg_chain": "0.2",
+                    "xg_buildup": "0.1",
+                },
+            },
+            {
+                "id": 102,
+                "stats": {
+                    "minutes": 90,
+                    "total_points": 7,
+                    "goals_scored": 0,
+                    "assists": 0,
+                    "goals_conceded": 0,
+                    "own_goals": 0,
+                    "penalties_saved": 0,
+                    "penalties_missed": 0,
+                    "yellow_cards": 0,
+                    "red_cards": 0,
+                    "saves": 4,
+                    "bps": 28,
+                    "bonus": 2,
+                    "total_shots": 0,
+                    "key_passes": 0,
+                    "influence": "25.0",
+                    "creativity": "2.0",
+                    "threat": "0.0",
+                    "expected_goals": "0.0",
+                    "expected_assists": "0.0",
+                    "xg_chain": "0.0",
+                    "xg_buildup": "0.0",
+                },
+            },
+        ]
+    }
+
+
+def test_generate_samples_basic(tmp_path):
+    raw_dir = tmp_path / "raw"
+    _write_json(raw_dir / "bootstrap-static.json", _build_bootstrap())
+    _write_json(raw_dir / "fixtures.json", _build_fixtures())
+    events_dir = raw_dir / "events"
+    _write_json(events_dir / "1.json", _event_payload(1))
+    _write_json(events_dir / "2.json", _event_payload(2))
+
+    output_path = tmp_path / "samples.csv"
+    df = generate_samples(raw_dir, output_path)
+
+    assert output_path.exists()
+    assert not df.empty
+
+    john_row = df[df["player"] == "John Doe"].iloc[0]
+    assert john_row["gw"] == 3
+    assert john_row["team"] == "Alpha FC"
+    assert bool(john_row["home"]) is True
+    assert np.isclose(john_row["player fpl points 1"], 2.0)
+    assert np.isclose(john_row["player fpl points 3"], 5.0)
+    assert np.isclose(john_row["player relevant fpl points 3"], 5.0)
+    assert np.isclose(john_row["team goals scored 1"], 0.0)
+    assert np.isclose(john_row["team goals scored 3"], 1.0)
+    assert np.isclose(john_row["opponent goals conceded 1"], 0.0)
+    assert john_row["status player availability"] == 1.0
+    assert john_row["status opponent league rank"] == 2.0
+    assert np.isnan(john_row["team deep allowed 1"])
+
+    jane_row = df[df["player"] == "Jane Smith"].iloc[0]
+    assert bool(jane_row["home"]) is False
+    assert jane_row["status player availability"] == 0.5
+    assert jane_row["status opponent league rank"] == 1.0
+    assert np.isclose(jane_row["opponent goals scored 1"], 0.0)
+
+    # The CSV should contain the same columns as the DataFrame
+    loaded = pd.read_csv(output_path)
+    assert list(loaded.columns) == list(df.columns)


### PR DESCRIPTION
## Summary
- add a simple FPL API client plus utilities to persist raw responses for later processing
- build a sample-generation pipeline that aggregates rolling player, team, and opponent features for the next gameweek and writes data/samples.csv
- provide CLI scripts and unit tests to refresh the cached data and validate sample generation behaviour, including dependency updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c957b66a9c832995c4eb5ebe62cf6f